### PR TITLE
Corrected typo in Autoprefixer options

### DIFF
--- a/generators/app/templates/webpack.config.js
+++ b/generators/app/templates/webpack.config.js
@@ -73,7 +73,7 @@ module.exports = {
         browsers: ['IE >= 10', 'last 2 version'],
         features: {
           autoprefixer: {
-            cascase: false
+            cascade: false
           }
         }
       })


### PR DESCRIPTION
Possible typo in autoprefixer options `cascase` corrected to `cascade`.
