### PR TITLE
npm → yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Basically, he wears a top hat, lives in your computer, and waits for you to tell
 Not every new computer comes with a Yeoman pre-installed. He lives in the [npm](https://npmjs.org) package repository. You only have to ask for him once, then he packs up and moves into your hard drive. *Make sure you clean up, he likes new and shiny things.*
 
 ```bash
-npm install -g yo
+yarn global add yo
 ```
 
 ### Yeoman Generators
@@ -25,13 +25,13 @@ Yeoman travels light. He didn't pack any generators when he moved in. You can th
 To install generator-devine-project from npm, run:
 
 ```bash
-npm install -g generator-devine-project
+yarn global add generator-devine-project
 ```
 
 Make sure you have nodemon, forever, webpack, babel and eslint installed as global modules
 
 ```bash
-npm install -g nodemon forever webpack babel eslint
+yarn global add nodemon forever webpack babel eslint
 ```
 
 Finally, initiate the generator:

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -17,7 +17,7 @@ module.exports = yeoman.generators.Base.extend({
 
     var done = this.async();
 
-    var default_author = exec('npm config get init.author.name', {encoding: 'utf-8'}) || '';
+    var default_author = exec('yarn config get init.author.name', {encoding: 'utf-8'}) || '';
 
     if(default_author.indexOf('\n') !== -1){
       default_author = default_author.split('\n')[0];
@@ -332,7 +332,7 @@ module.exports = yeoman.generators.Base.extend({
       spawn('git', ['init'], { stdio: 'inherit' });
     }
 
-    spawn('npm', ['install'], { stdio: 'inherit' });
+    spawn('yarn', ['install'], { stdio: 'inherit' });
 
     spawn('webpack', { stdio: 'inherit' });
 
@@ -341,7 +341,7 @@ module.exports = yeoman.generators.Base.extend({
       spawn('git', ['commit', '-m', '"initial commit"'], { stdio: 'inherit' });
     }
 
-    spawn('npm', ['run', 'development'], { stdio: 'inherit' });
+    spawn('yarn', ['run', 'development'], { stdio: 'inherit' });
 
   }
 

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",<% } %>
   "author": "<%= author %>",
   "scripts": {
-    "development": "webpack --watch & npm run serve",
+    "development": "webpack --watch & yarn run serve",
     "production": "webpack -d -p",<% if (node) { %>
     "start": "forever --minUptime 1000 --spinSleepTime 1000 .",<% } %><% if (test) { %>
     "test": "mocha --compilers js:babel-core/register --recursive",<% } %>


### PR DESCRIPTION
Indien gewenst een ready to go transition van npm naar yarn.
Enige issue waar ik momenteel nog op denk: Procfile voor heroku gebruikt nog steeds `npm start` aangezien ik niet denk dat het mogelijk is om een Heroku instance yarn te laten gebruiken.
