### PR TITLE
devtool option in webpack is waarschijnlijk invalid

### DIFF
--- a/generators/app/templates/webpack.config.js
+++ b/generators/app/templates/webpack.config.js
@@ -50,7 +50,7 @@ const config = {
     publicPath
   },
 
-  devtool: `sourcemap`,<% if (!node) { %>
+  devtool: `source-map`,<% if (!node) { %>
 
   devServer: {
     contentBase: `./src`,


### PR DESCRIPTION
Volgens de v2 docs is sourcemap geen geldige option.
Er zijn nog wat 'humble student opinions' die ik heb over webpack maar deze giet ik in #13 .

Ref: https://webpack.js.org/configuration/devtool/#devtool