### PR TITLE
➕ Add zeit/serve to replace local-web-server

### DIFF
--- a/generators/app/templates/.babelrc
+++ b/generators/app/templates/.babelrc
@@ -19,7 +19,13 @@
       ]
     },
 
-    <% } %>"production": {
+    <% } %>
+    <% if (jest) { %>"test": {
+      "presets": ["es2015"]           
+    },
+    <% } %>
+
+    "production": {
       "plugins": [
         "lodash"<% if (react) { %>,
         "transform-react-remove-prop-types"<% } %>

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "development": "npm run clean && <% if (node) { %>nodemon . & NODE_ENV=development webpack --watch<% } else { %>NODE_ENV=development webpack-dev-server --open<% } %>",<% if (node) { %>
     "start": "npm run serve",<% } %>
-    "serve": "<% if (node) { %>forever .<% } else { %>ws -d ./dist -c -p 3000 <% if (reactRouter) { %>-s<% } %><% } %>",
+    "serve": "<% if (node) { %>forever .<% } else { %>serve ./dist -p 3000<% if (reactRouter) { %> -s<% } %><% } %>",
     "clean": "rimraf <% if (node) { %>./server/public/<% } else { %>./dist<% } %>",
     "production": "npm run clean && NODE_ENV=production webpack -p"<% if (jest) { %>,
     "test": "jest --coverage"<% } %><% if (flow) {%>,
@@ -64,7 +64,7 @@
     <% } %><% if (reactRouter) { %>"react-router": "next",
     <% } %><% } %><% if (!node) { %>"react-dev-utils": "^0.4.2",
     "webpack-dev-server": "beta",
-    "local-web-server": "^1.2.6",
+    "serve": "^2.1.2",
     <% } %>"rimraf": "^2.5.4",
     "style-loader": "^0.13.1",
     "stylelint": "^7.7.1",


### PR DESCRIPTION
Closes #32 

Added the space before the -s flag (seemed more logical, otherwise there would be trailing whitespace in the run script if reactRouter was false).

Some other stuff you could optionally pass: `-i` to ignore files when serve runs in list mode, augment the caching limit with `-c` (default 3600)