### PR TITLE
🐛 Add babel-preset-es2015 for the NODE_ENV=test

### DIFF
--- a/generators/app/templates/.babelrc
+++ b/generators/app/templates/.babelrc
@@ -19,7 +19,13 @@
       ]
     },
 
-    <% } %>"production": {
+    <% } %>
+    <% if (jest) { %>"test": {
+      "presets": ["es2015"]           
+    },
+    <% } %>
+
+    "production": {
       "plugins": [
         "lodash"<% if (react) { %>,
         "transform-react-remove-prop-types"<% } %>

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "development": "npm run clean && <% if (node) { %>nodemon . & NODE_ENV=development webpack --watch<% } else { %>NODE_ENV=development webpack-dev-server --open<% } %>",<% if (node) { %>
     "start": "npm run serve",<% } %>
-    "serve": "<% if (node) { %>forever .<% } else { %>ws -d ./dist -c -p 3000 <% if (reactRouter) { %>-s<% } %><% } %>",
+    "serve": "<% if (node) { %>forever .<% } else { %>serve ./dist -p 3000<% if (reactRouter) { %> -s<% } %><% } %>",
     "clean": "rimraf <% if (node) { %>./server/public/<% } else { %>./dist<% } %>",
     "production": "npm run clean && NODE_ENV=production webpack -p"<% if (jest) { %>,
     "test": "jest --coverage"<% } %><% if (flow) {%>,
@@ -64,7 +64,7 @@
     <% } %><% if (reactRouter) { %>"react-router": "next",
     <% } %><% } %><% if (!node) { %>"react-dev-utils": "^0.4.2",
     "webpack-dev-server": "beta",
-    "local-web-server": "^1.2.6",
+    "serve": "^2.1.2",
     <% } %>"rimraf": "^2.5.4",
     "style-loader": "^0.13.1",
     "stylelint": "^7.7.1",


### PR DESCRIPTION
> Without this Jest will not be able to use import and other features that currently need to be transpiled with babel.

### Screenshot failing:
![image](https://cloud.githubusercontent.com/assets/6213695/21850864/ed54bf2c-d80c-11e6-8a02-d805205a0002.png)

### Screenshot with changes in this PR applied:
![image](https://cloud.githubusercontent.com/assets/6213695/21850902/1f7bf6d2-d80d-11e6-82ff-bfbf8be0cade.png)

Would have seemed logical that setting the global preset es2015 would also take care of Jest, but my guess is since that Jest exports a new env or runs under NODE_ENV=test that this doesn't work.
This is one of the reasons Jest 17+ was needed in #31 