### PR TITLE
🔧  Removed babel-preset-es2015 in favour of babel-preset-env

### DIFF
--- a/generators/app/templates/.babelrc
+++ b/generators/app/templates/.babelrc
@@ -4,7 +4,7 @@
     ["env", {
       "targets": {
         <% if(node) { %>"node": "current",<% } %>
-        "browsers": ["last 2 versions", "ie >= 11"]
+        "browsers": ["last 2 versions", "ie >= 10"]
       },
       "modules": false,
       "loose": true

--- a/generators/app/templates/.babelrc
+++ b/generators/app/templates/.babelrc
@@ -29,7 +29,7 @@
     },<% } %>
 
     <% if (jest) { %>"test": {
-      "presets": ["es2015"]
+      "presets": ["env", targets: {"node": "current"}]
     },<% } %>
 
     "production": {

--- a/generators/app/templates/.babelrc
+++ b/generators/app/templates/.babelrc
@@ -1,7 +1,14 @@
 {
 
   "presets": [
-    ["es2015", { "modules": false, "loose": true }]<% if (react) { %>,
+    ["env", {
+      "targets": {
+        <% if(node) { %>"node": "current",<% } %>
+        "browsers": ["last 2 versions", "ie >= 11"]
+      },
+      "modules": false,
+      "loose": true
+      }]<% if (react) { %>,
     "react"<% } %>
   ],
 

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -40,7 +40,7 @@
     "babel-plugin-transform-react-stateless-component-name": "^1.1.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-react": "^6.16.0",
-    <% } %>"babel-preset-es2015": "^6.18.0",
+    <% } %>"babel-preset-env": "^1.2.0",
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "copy-webpack-plugin": "^4.0.1",


### PR DESCRIPTION
Base for #37
IE >= 11 looked realistic to me ¯\_(ツ)_/¯